### PR TITLE
fix!: allow the user to specify a buffer for `read`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,13 +453,10 @@ impl AIOManager {
         &self,
         fd: RawFd,
         offset: u64,
-        length: usize,
+        data: Box<[u8]>,
         priority: Option<u16>,
     ) -> AIOFuture {
         let priority = priority.unwrap_or(0);
-        let mut data = Vec::new();
-        data.resize(length, 0);
-        let data = data.into_boxed_slice();
         let aio = AIO::new(
             self.scheduler_in.next_id(),
             fd,


### PR DESCRIPTION
`Vec::new()` returns a vector with an unaligned allocation, causing the kernel to return EINVAL during reading.

Some devices/filesystems seems to not care about alignment, but I've stumbled upon some cases where alignment is important. E.g., my laptop NVMe SSD does not care about alignment, while my SATA HDD (attached via USB enclosure) does.